### PR TITLE
Drop PHP `8.4` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.4', '8.5']
+        php-version: ['8.5']
         dependencies: ['lowest', 'highest']
     name: 'Composer'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Requires PHP `8.5`

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "http://github.com/innmind/foundation/issues"
     },
     "require": {
-        "php": "~8.4",
+        "php": "~8.5",
         "innmind/immutable": "~6.0",
         "innmind/mutable": "~1.0",
         "innmind/http": "~9.0",


### PR DESCRIPTION
Since the latest version of `innmind/url` requires `8.5` essentially all the packages can move to `8.5` as well.